### PR TITLE
Setup reusable workflow for Security scanning using Trivy

### DIFF
--- a/.github/actions/tools/trivy/action.yml
+++ b/.github/actions/tools/trivy/action.yml
@@ -1,0 +1,48 @@
+name: Trivy Scanning Action
+description: Run Trivy security scanning
+
+inputs:
+  scanning-directory:
+    required: true
+    default: "."
+    description: The folder the scanner looks at
+  severity:
+    required: false
+    default: 'MEDIUM,HIGH,CRITICAL'
+    description: "Comma-separated list of severities to scan for possible alternatives: LOW, MEDIUM, HIGH, CRITICAL"
+  scan-command:
+    required: true
+    default: 'config'
+    description: |
+      The trivy scan command to run. Valid values:
+        - config      Scan config files for misconfigurations
+        - filesystem  Scan local filesystem
+        - image       Scan a container image
+        - kubernetes  Scan kubernetes cluster
+        - repository  Scan a repository
+        - rootfs      Scan rootfs
+        - sbom        Scan SBOM for vulnerabilities and licenses
+        - vm          Scan a virtual machine image
+  ignore-unfixed:
+    required: true
+    default: 'false'
+    description: "Ignore vulnerabilities that doesn't have a known fix"
+
+runs:
+  using: composite
+  steps:
+    - name: Run Trivy vulnerability scanner
+      uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # 0.28.0
+      with:
+        scan-type: ${{ inputs.scan-command }}
+        format: 'sarif'
+        output: 'trivy-results.sarif'
+        scan-ref: ${{ inputs.scanning-directory }}
+        severity: ${{ inputs.severity }}
+        ignore-unfixed: ${{ inputs.ignore-unfixed }}
+      continue-on-error: true
+
+    - name: Upload Trivy scan results to GitHub Security tab
+      uses: github/codeql-action/upload-sarif@fdbfb4d2750291e159f0156def62b853c2798ca2 # v4.31.5
+      with:
+        sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/security.scan.terraform.yml
+++ b/.github/workflows/security.scan.terraform.yml
@@ -1,0 +1,46 @@
+name: Security Scan terraform
+on:
+  workflow_call:
+    inputs:
+      scanning-directory:
+        description: "Directory where the scan should run from"
+        required: false
+        type: string
+        default: "."
+      severity:
+        description: "Comma-separated list of severities to scan for possible alternatives: LOW, MEDIUM, HIGH, CRITICAL"
+        required: false
+        type: string
+        # LOW and MEDIUM severities can be quite noisy.
+        # Better to default on the higher severities
+        default: "HIGH,CRITICAL"
+      scan-command:
+        description: "The trivy scan command to run (e.g. config, filesystem, image, repository, rootfs, sbom, vm, kubernetes)"
+        required: false
+        type: string
+        default: "config"
+      ignore-unfixed:
+        required: false
+        type: boolean
+        # Unfixed vulnerabilities are of course problematic,
+        # but also not much we can do anything about. Hence, this can also be noisy in a pipeline.
+        default: true
+        description: "Ignore vulnerabilities that doesn't have a known fix. Defaults to true"
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  scan-terraform:
+    name: Security Scan Terraform
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - uses: nsbno/platform-actions/.github/actions/tools/trivy@trivy-github-action
+        with:
+          scanning-directory: ${{ inputs.scanning-directory }}
+          severity: ${{ inputs.severity }}
+          scan-command: ${{ inputs.scan-command }}
+          ignore-unfixed: ${{ inputs.ignore-unfixed }}


### PR DESCRIPTION
Satt opp ein action for å køyre Trivy.
I sjølve workflowen prøver eg å unngå å henvise direkte til Trivy, men heller halde namnet generelt mot "Sikkerhetsscanning av Terraform". Gjev oss litt ekstra fleksibilitet om vi seinare finner noko betre enn Trivy.

Tar gjerne input på kva namnet på workflow fila bør vere. Passa inn under `helpers.*` men kanskje det burde vore noko nytt?

Brukar denne i https://github.com/nsbno/terraform-aws-topic-subscription/blob/main/.github/workflows/validate.yml