### PR TITLE
Allow branch deploy to forcefully skip ECS deploy

### DIFF
--- a/.github/actions/deployment/get-application-deployment-info/action.yml
+++ b/.github/actions/deployment/get-application-deployment-info/action.yml
@@ -48,6 +48,13 @@ runs:
         GITHUB_REPOSITORY: ${{ inputs.github-repository-name }}
         WORKING_DIRECTORY: ${{ inputs.working-directory }}
         ECR_REPOSITORY_NAME: ${{ inputs.ecr-repository-name }}
+      # There is a bug here related to auto discovery.
+      # When you have 1) a service that doesn't have an ECS service, i.e.
+      # you're missing the expected SSM parameters.
+      # 2) There are other ECS services in the account, we get the problem when there were >1,
+      # but it's applicable for just 1 service too.
+      # Then it will incorrectly identify those ECS services as matches in the auto-discovery
+      # when they are not part of the correct Github repository or service.
       run: |
         GIT_REPO_NAME="${GITHUB_REPOSITORY##*/}"
 

--- a/.github/workflows/deployment.branch-deploy.on-comment.yml
+++ b/.github/workflows/deployment.branch-deploy.on-comment.yml
@@ -26,6 +26,11 @@ on:
         type: boolean
         default: false
         required: false
+      skip-ecs-deploy:
+        description: Allow you to forcefully ignore the ECS deploy step. Only use if strictly necessary
+        type: boolean
+        default: false
+        required: false
       ecr-repository-names:
         description: "List of ECR repository names for multi-service in one Terraform config (JSON array format)."
         type: string
@@ -105,7 +110,7 @@ jobs:
 
   test-deploy:
     name: Test - Deploy
-    uses: nsbno/platform-actions/.github/workflows/deployment.single-environment.yml@v2
+    uses: nsbno/platform-actions/.github/workflows/deployment.single-environment.yml@allow-skip-ecs-deploy
     needs: trigger-test
     if: |
       always()
@@ -120,10 +125,11 @@ jobs:
       ecr-repository-names: ${{ inputs.ecr-repository-names }}
       s3-static-files-path: ${{ inputs.s3-static-files-path }}
       skip-static-files-deployment: ${{ inputs.skip-static-files-deployment }}
+      skip-ecs-deploy: ${{ inputs.skip-ecs-deploy }}
 
   stage-deploy:
     name: Stage - Deploy
-    uses: nsbno/platform-actions/.github/workflows/deployment.single-environment.yml@v2
+    uses: nsbno/platform-actions/.github/workflows/deployment.single-environment.yml@allow-skip-ecs-deploy
     needs: trigger-stage
     if: |
       always()
@@ -138,6 +144,8 @@ jobs:
       ecr-repository-names: ${{ inputs.ecr-repository-names }}
       s3-static-files-path: ${{ inputs.s3-static-files-path }}
       skip-static-files-deployment: ${{ inputs.skip-static-files-deployment }}
+      skip-ecs-deploy: ${{ inputs.skip-ecs-deploy }}
+
 
   comment-handler:
     needs: [ trigger-test, trigger-stage, test-deploy, stage-deploy ]

--- a/.github/workflows/deployment.single-environment.yml
+++ b/.github/workflows/deployment.single-environment.yml
@@ -35,6 +35,11 @@ on:
         type: boolean
         default: false
         required: false
+      skip-ecs-deploy:
+        description: Allow you to forcefully ignore the ECS deploy step. Only use if strictly necessary
+        type: boolean
+        default: false
+        required: false
       ecr-repository-names:
         description: "List of ECR repository names for multi-service in one Terraform config (JSON array format)."
         type: string
@@ -65,6 +70,7 @@ jobs:
       always()
       && !cancelled()
       && needs.deploy-terraform.result != 'failure'
+      && !inputs.skip-ecs-deploy
     with:
       environment: ${{ inputs.environment }}
       working-directory: ${{ inputs.working-directory }}


### PR DESCRIPTION
Mainly used as an escape hatch for certain situations where you have trouble getting the pipeline to
skip the ECS deployments part