### PR TITLE
Give terraform access to Git SHA through TF_VAR_git_sha

### DIFF
--- a/.github/actions/tools/terraform/action.yml
+++ b/.github/actions/tools/terraform/action.yml
@@ -33,7 +33,7 @@ inputs:
     required: true
   git-sha:
     required: true
-    description: "Git SHA to use for versioning"
+    description: "Git SHA to use for versioning. Is passed to terraform as environment variable TF_VAR_git_sha"
   version-handler-api-endpoint:
     required: false
     description: "Version handler API endpoint for artifact versioning"
@@ -118,6 +118,11 @@ runs:
       if: steps.restore-terraform.outputs.cache-hit == 'false' || inputs.always-run-init == 'true'
       shell: bash
       working-directory: ${{ steps.tf-dir.outputs.dir }}
+      env:
+        # Give terraform access to the Git Commit Sha that the pipeline uses
+        # through a variable. Typically not needed by them, but useful when they need
+        # to break the abstraction
+        TF_VAR_git_sha: ${{ inputs.git-sha }}
       run: |
         set -e
         terraform init --backend=${{ inputs.terraform-use-backend }}
@@ -126,6 +131,11 @@ runs:
       working-directory: ${{ steps.tf-dir.outputs.dir }}
       id: terraform
       shell: bash
+      env:
+        # Give terraform access to the Git Commit Sha that the pipeline uses
+        # through a variable. Typically not needed by them, but useful when they need
+        # to break the abstraction
+        TF_VAR_git_sha: ${{ inputs.git-sha }}
       run: terraform ${{ inputs.terraform-command }} ${{ inputs.terraform-options }}
 
     # Workaround for releasing lock if cancelling a Terraform job

--- a/.github/workflows/deployment.all-environments-terraform.yml
+++ b/.github/workflows/deployment.all-environments-terraform.yml
@@ -74,7 +74,7 @@ jobs:
   # Service always needs to be deployed first, and we only deploy Terraform changes.
   service-terraform:
     name: Service - Terraform
-    uses: nsbno/platform-actions/.github/workflows/deployment.single-environment-terraform.yml@v2
+    uses: nsbno/platform-actions/.github/workflows/deployment.single-environment-terraform.yml@forward-git-sha-as-variable-to-terraform
     needs: get-environments
     if: |
       always()
@@ -83,6 +83,7 @@ jobs:
       && contains(needs.get-environments.outputs.environments, 'Service')
     with:
       environment: Service
+      sha-to-deploy: ${{ inputs.sha-to-deploy }}
       deploy-terraform: ${{ contains(fromJSON(inputs.terraform-changes), 'Service') }}
       working-directory: ${{ inputs.working-directory }}
       terraform-directory: ${{ inputs.terraform-directory }}
@@ -90,7 +91,7 @@ jobs:
 
   test-terraform:
     name: Test - Terraform
-    uses: nsbno/platform-actions/.github/workflows/deployment.single-environment-terraform.yml@v2
+    uses: nsbno/platform-actions/.github/workflows/deployment.single-environment-terraform.yml@forward-git-sha-as-variable-to-terraform
     needs:
       - service-terraform
       - get-environments
@@ -101,6 +102,7 @@ jobs:
       && contains(needs.get-environments.outputs.environments, 'Test')
     with:
       environment: Test
+      sha-to-deploy: ${{ inputs.sha-to-deploy }}
       deploy-terraform: ${{ contains(fromJSON(inputs.terraform-changes), 'Test') }}
       working-directory: ${{ inputs.working-directory }}
       terraform-directory: ${{ inputs.terraform-directory }}
@@ -108,7 +110,7 @@ jobs:
 
   stage-terraform:
     name: Stage - Terraform
-    uses: nsbno/platform-actions/.github/workflows/deployment.single-environment-terraform.yml@v2
+    uses: nsbno/platform-actions/.github/workflows/deployment.single-environment-terraform.yml@forward-git-sha-as-variable-to-terraform
     needs:
       - service-terraform
       - get-environments
@@ -119,6 +121,7 @@ jobs:
       && contains(needs.get-environments.outputs.environments, 'Stage')
     with:
       environment: Stage
+      sha-to-deploy: ${{ inputs.sha-to-deploy }}
       deploy-terraform: ${{ contains(fromJSON(inputs.terraform-changes), 'Stage') }}
       working-directory: ${{ inputs.working-directory }}
       terraform-directory: ${{ inputs.terraform-directory }}
@@ -126,7 +129,7 @@ jobs:
 
   production-terraform:
     name: Prod - Terraform
-    uses: nsbno/platform-actions/.github/workflows/deployment.single-environment-terraform.yml@v2
+    uses: nsbno/platform-actions/.github/workflows/deployment.single-environment-terraform.yml@forward-git-sha-as-variable-to-terraform
     needs:
       - stage-terraform
       - test-terraform
@@ -138,6 +141,7 @@ jobs:
       && contains(needs.get-environments.outputs.environments, 'Production')
     with:
       environment: Production
+      sha-to-deploy: ${{ inputs.sha-to-deploy }}
       deploy-terraform: ${{ contains(fromJSON(inputs.terraform-changes), 'Production') }}
       working-directory: ${{ inputs.working-directory }}
       terraform-directory: ${{ inputs.terraform-directory }}

--- a/.github/workflows/deployment.single-environment-terraform.yml
+++ b/.github/workflows/deployment.single-environment-terraform.yml
@@ -64,7 +64,7 @@ jobs:
         with:
           environment: ${{ inputs.environment }}
 
-      - uses: nsbno/platform-actions/.github/actions/tools/terraform@v2
+      - uses: nsbno/platform-actions/.github/actions/tools/terraform@forward-git-sha-as-variable-to-terraform
         name: Terraform Apply
         with:
           env-mapping-directory: ${{ steps.env-mapping.outputs.directory }}

--- a/.github/workflows/deployment.single-environment.yml
+++ b/.github/workflows/deployment.single-environment.yml
@@ -49,7 +49,7 @@ on:
 jobs:
   deploy-terraform:
     name: Terraform Apply
-    uses: nsbno/platform-actions/.github/workflows/deployment.single-environment-terraform.yml@v2
+    uses: nsbno/platform-actions/.github/workflows/deployment.single-environment-terraform.yml@forward-git-sha-as-variable-to-terraform
     if: |
       always()
       && !cancelled()


### PR DESCRIPTION
Useful in case they need access to it for other use-cases or they cannot use `vy_lambda_artifacts`. 

Git SHA isn't as straight forward to retrieve directly in github. So it is better that our actions just pass it to them