### PR TITLE
Allow specifying Git SHA in package.docker.yml

### DIFF
--- a/.github/workflows/package.docker.yml
+++ b/.github/workflows/package.docker.yml
@@ -39,6 +39,10 @@ on:
         type: string
         description: "The AWS role name to assume. Used for migration purposes for teams using older GHA roles."
         default: ${{ vars.AWS_DEPLOYMENT_ROLE_NAME }}
+      git-sha:
+        required: false
+        type: string
+        description: "Git SHA to checkout at, and to use as image tag. Falls back to SHA of the workflow context if not provided."
 
 name: Upload Deployable to ECR
 
@@ -53,6 +57,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.git-sha || github.sha }}
 
       - name: Download Artifact
         if: inputs.artifact-name != ''
@@ -90,7 +96,7 @@ jobs:
           file: ${{ inputs.working-directory }}/${{ inputs.dockerfile }}
           push: true
           tags: |
-            ${{ steps.login-ecr.outputs.registry }}/${{ inputs.ecr-repo-name }}:${{ github.event.pull_request.head.sha || github.sha }}
+            ${{ steps.login-ecr.outputs.registry }}/${{ inputs.ecr-repo-name }}:${{ inputs.git-sha || github.event.pull_request.head.sha || github.sha }}
             ${{ steps.login-ecr.outputs.registry }}/${{ inputs.ecr-repo-name }}:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
## Description
Supports deployment of a specific Git SHA, by ensuring that the ECR image is tagged with this specific SHA.

## Changelog
- Adds optional `git-sha` input variable to `package.docker.yml `
  - Keeps original workflow functionality if git-sha is not provided ([actions/checkout-v4](https://github.com/actions/checkout?tab=readme-ov-file#checkout-v4) checks out at `github.sha` by default)

## The issue to be fixed
It is currently not possible to deploy a specific, non-latest Git SHA, because `package.docker.yml` tags the ECR image with the latest Git SHA for non-PR runs.

Our team has a triggerable workflow (workflow_dispatch) that deploys a given Git SHA. It:
* passes the SHA to `find-changes.terraform.yml` and `build.gradle.yml`
* calls `package.docker.yml` (without SHA, as there is no input variable)
  * which tags the image using `github.sha` (latest commit in the branch selected to run our workflow)
* passes the SHA to `deployment.single-environment.yml`
  * which attempts to pull ECR image with the specified SHA, but fails because because no such image exists

I have verified that this fix works for our triggerable workflow ✅ 