### PR TITLE
Add authentication step

### DIFF
--- a/.github/actions/tools/npm/action.yml
+++ b/.github/actions/tools/npm/action.yml
@@ -32,6 +32,15 @@ runs:
         cache: 'npm'
         cache-dependency-path: ${{ inputs.working-directory }}/package-lock.json
 
+    - name: Authenticate with Nexus repository
+      shell: bash
+      env:
+        NEXUS_USERNAME: ${{ inputs.NEXUS_USERNAME }}
+        NEXUS_PASSWORD: ${{ inputs.NEXUS_PASSWORD }}
+      run: |
+        TOKEN=$(echo -n $NEXUS_USERNAME:$NEXUS_PASSWORD | base64)
+        npm config set "//nexus.common-services.vydev.io/repository/npm-group/:_auth=$TOKEN"
+
     - name: Run NPM Install
       working-directory: ${{ inputs.working-directory }}
       shell: bash

--- a/.github/actions/tools/pnpm/action.yml
+++ b/.github/actions/tools/pnpm/action.yml
@@ -42,6 +42,15 @@ runs:
         cache: 'pnpm'
         cache-dependency-path: '${{ inputs.working-directory }}/pnpm-lock.yaml'
 
+    - name: Authenticate with Nexus repository
+      shell: bash
+      env:
+        NEXUS_USERNAME: ${{ inputs.NEXUS_USERNAME }}
+        NEXUS_PASSWORD: ${{ inputs.NEXUS_PASSWORD }}
+      run: |
+        TOKEN=$(echo -n $NEXUS_USERNAME:$NEXUS_PASSWORD | base64)
+        npm config set "//nexus.common-services.vydev.io/repository/npm-group/:_auth=$TOKEN"
+
     - name: Run pnpm Install
       working-directory: ${{ inputs.working-directory }}
       shell: bash


### PR DESCRIPTION
This pull request adds authentication steps for the Nexus repository to both the npm and pnpm GitHub Actions workflows. This ensures that package installations can access private packages hosted on Nexus by configuring npm with the appropriate authentication token.

**CI/CD workflow enhancements:**

* Added a step to the `.github/actions/tools/npm/action.yml` workflow to authenticate with the Nexus repository using credentials provided via environment variables, and configure npm to use the generated token.
* Added a similar authentication step to the `.github/actions/tools/pnpm/action.yml` workflow, enabling access to Nexus-hosted packages during pnpm installs.