### PR TITLE
Terraform plan

### DIFF
--- a/.github/workflows/helpers.terraform-plan.on-comment.yml
+++ b/.github/workflows/helpers.terraform-plan.on-comment.yml
@@ -90,7 +90,7 @@ jobs:
 
   plan:
     needs: trigger
-    uses: nsbno/platform-actions/.github/workflows/helpers.terraform-plan.yml@v2
+    uses: nsbno/platform-actions/.github/workflows/helpers.terraform-plan.yml@terraform-plan
     with:
       working-directory: ${{ inputs.working-directory }}
       terraform-directory: ${{ inputs.terraform-directory }}

--- a/.github/workflows/helpers.terraform-plan.on-comment.yml
+++ b/.github/workflows/helpers.terraform-plan.on-comment.yml
@@ -90,7 +90,7 @@ jobs:
 
   plan:
     needs: trigger
-    uses: nsbno/platform-actions/.github/workflows/helpers.terraform-plan.yml@terraform-plan
+    uses: nsbno/platform-actions/.github/workflows/helpers.terraform-plan.yml@v2
     with:
       working-directory: ${{ inputs.working-directory }}
       terraform-directory: ${{ inputs.terraform-directory }}

--- a/.github/workflows/helpers.terraform-plan.yml
+++ b/.github/workflows/helpers.terraform-plan.yml
@@ -117,10 +117,8 @@ jobs:
             fi
 
             cat << EOF > "plans/${ENVIRONMENT}.md"
-          ### Terraform Plan for ${ENVIRONMENT}${WORKING_DIRECTORY_SUFFIX}
-
           <details>
-          <summary>Show Plan</summary>
+          <summary>Show Plan for ${ENVIRONMENT}${WORKING_DIRECTORY_SUFFIX}</summary>
 
           \`\`\`terraform
           $PLAN_CONTENT
@@ -130,9 +128,12 @@ jobs:
           EOF
           else
             cat << EOF > "plans/${ENVIRONMENT}.md"
-          ### Terraform Plan for ${ENVIRONMENT}${WORKING_DIRECTORY_SUFFIX}
+          <details>
+          <summary>Show Plan for ${ENVIRONMENT}${WORKING_DIRECTORY_SUFFIX}</summary>
 
           _No changes detected._
+
+          </details>
           EOF
           fi
 
@@ -171,7 +172,7 @@ jobs:
           COMMENT_FILE=$(mktemp)
 
           cat << EOF > "$COMMENT_FILE"
-          ## Terraform Plan 🔍
+          ### Terraform Plan 🔍
           *For commit ${{ inputs.git-sha }}*
           *Plan generated at: $(TZ="Europe/Oslo" date "+%Y-%m-%d %H:%M:%S %Z")*
 

--- a/.github/workflows/helpers.terraform-plan.yml
+++ b/.github/workflows/helpers.terraform-plan.yml
@@ -90,24 +90,13 @@ jobs:
           version-handler-api-endpoint: ${{ inputs.version-handler-api-endpoint }}
 
       - name: Save plan output
-        if: (github.event_name == 'pull_request' || github.event_name == 'issue_comment') && steps.changed-files.outputs.any-changed == 'true'
+        if: github.event_name == 'pull_request' || github.event_name == 'issue_comment'
         shell: bash
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
           ENVIRONMENT: ${{ matrix.environment }}
           WORKING_DIRECTORY: ${{ inputs.working-directory }}
+          ANY_CHANGED: ${{ steps.changed-files.outputs.any-changed }}
         run: |
-          PLAN_OUTPUT=$(cat << 'EOF'
-          ${{ steps.changed-files.outputs.stdout }}
-          EOF
-          )
-          
-          PLAN_CONTENT=$(echo "$PLAN_OUTPUT" | sed -n '/Terraform used the selected providers/,$p')
-          if [ -z "$PLAN_CONTENT" ]; then
-            PLAN_CONTENT="$PLAN_OUTPUT"
-          fi
-
           if [ -n "$WORKING_DIRECTORY" ] && [ "$WORKING_DIRECTORY" != "." ]; then
             WORKING_DIRECTORY_SUFFIX=" in ${WORKING_DIRECTORY}"
           else
@@ -115,7 +104,19 @@ jobs:
           fi
 
           mkdir -p plans
-          cat << EOF > "plans/${ENVIRONMENT}.md"
+
+          if [ "$ANY_CHANGED" == "true" ]; then
+            PLAN_OUTPUT=$(cat << 'PLANEOF'
+          ${{ steps.changed-files.outputs.stdout }}
+          PLANEOF
+            )
+
+            PLAN_CONTENT=$(echo "$PLAN_OUTPUT" | sed -n '/Terraform used the selected providers/,$p')
+            if [ -z "$PLAN_CONTENT" ]; then
+              PLAN_CONTENT="$PLAN_OUTPUT"
+            fi
+
+            cat << EOF > "plans/${ENVIRONMENT}.md"
           ### Terraform Plan for ${ENVIRONMENT}${WORKING_DIRECTORY_SUFFIX} 🔍
 
           <details>
@@ -127,9 +128,16 @@ jobs:
 
           </details>
           EOF
+          else
+            cat << EOF > "plans/${ENVIRONMENT}.md"
+          ### Terraform Plan for ${ENVIRONMENT}${WORKING_DIRECTORY_SUFFIX} 🔍
+
+          _No changes detected._
+          EOF
+          fi
 
       - name: Upload plan artifact
-        if: (github.event_name == 'pull_request' || github.event_name == 'issue_comment') && steps.changed-files.outputs.any-changed == 'true'
+        if: github.event_name == 'pull_request' || github.event_name == 'issue_comment'
         uses: actions/upload-artifact@v6
         with:
           name: terraform-plan-${{ matrix.environment }}

--- a/.github/workflows/helpers.terraform-plan.yml
+++ b/.github/workflows/helpers.terraform-plan.yml
@@ -89,7 +89,7 @@ jobs:
           git-sha: ${{ inputs.git-sha }}
           version-handler-api-endpoint: ${{ inputs.version-handler-api-endpoint }}
 
-      - name: Add Terraform Plan to PR
+      - name: Save plan output
         if: (github.event_name == 'pull_request' || github.event_name == 'issue_comment') && steps.changed-files.outputs.any-changed == 'true'
         shell: bash
         env:
@@ -107,31 +107,74 @@ jobs:
           if [ -z "$PLAN_CONTENT" ]; then
             PLAN_CONTENT="$PLAN_OUTPUT"
           fi
-      
-          COMMENT_FILE=$(mktemp)
-          
+
           if [ -n "$WORKING_DIRECTORY" ] && [ "$WORKING_DIRECTORY" != "." ]; then
             WORKING_DIRECTORY_SUFFIX=" in ${WORKING_DIRECTORY}"
           else
             WORKING_DIRECTORY_SUFFIX=""
           fi
-      
-          cat << EOF > "$COMMENT_FILE"
+
+          mkdir -p plans
+          cat << EOF > "plans/${ENVIRONMENT}.md"
           ### Terraform Plan for ${ENVIRONMENT}${WORKING_DIRECTORY_SUFFIX} 🔍
-      
+
           <details>
           <summary>Show Plan</summary>
-      
+
           \`\`\`terraform
           $PLAN_CONTENT
           \`\`\`
-      
+
           </details>
-      
+          EOF
+
+      - name: Upload plan artifact
+        if: (github.event_name == 'pull_request' || github.event_name == 'issue_comment') && steps.changed-files.outputs.any-changed == 'true'
+        uses: actions/upload-artifact@v6
+        with:
+          name: terraform-plan-${{ matrix.environment }}
+          path: plans/${{ matrix.environment }}.md
+
+  publish-plan:
+    name: Publish Terraform Plan
+    needs: terraform-plan
+    if: always() && (github.event_name == 'pull_request' || github.event_name == 'issue_comment') && needs.terraform-plan.result != 'skipped'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Download all plan artifacts
+        uses: actions/download-artifact@v6
+        with:
+          pattern: terraform-plan-*
+          path: plans
+          merge-multiple: true
+
+      - name: Post combined PR comment
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+        run: |
+          COMMENT_FILE=$(mktemp)
+
+          for plan_file in plans/*.md; do
+            [ -f "$plan_file" ] || continue
+            cat "$plan_file" >> "$COMMENT_FILE"
+            echo "" >> "$COMMENT_FILE"
+          done
+
+          if [ ! -s "$COMMENT_FILE" ]; then
+            echo "No plan changes to post."
+            exit 0
+          fi
+
+          cat << EOF >> "$COMMENT_FILE"
           *For commit ${{ inputs.git-sha }}*
           *Plan generated at: $(date -u "+%Y-%m-%d %H:%M:%S UTC")*
           EOF
-      
+
           gh pr comment $PR_NUMBER --body-file "$COMMENT_FILE"
-      
+
           rm "$COMMENT_FILE"
+

--- a/.github/workflows/helpers.terraform-plan.yml
+++ b/.github/workflows/helpers.terraform-plan.yml
@@ -142,6 +142,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/helpers.terraform-plan.yml
+++ b/.github/workflows/helpers.terraform-plan.yml
@@ -143,6 +143,9 @@ jobs:
     permissions:
       pull-requests: write
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
       - name: Download all plan artifacts
         uses: actions/download-artifact@v6
         with:
@@ -177,4 +180,3 @@ jobs:
           gh pr comment $PR_NUMBER --body-file "$COMMENT_FILE"
 
           rm "$COMMENT_FILE"
-

--- a/.github/workflows/helpers.terraform-plan.yml
+++ b/.github/workflows/helpers.terraform-plan.yml
@@ -173,7 +173,7 @@ jobs:
           cat << EOF > "$COMMENT_FILE"
           ## Terraform Plan 🔍
           *For commit ${{ inputs.git-sha }}*
-          *Plan generated at: $(date -u "+%Y-%m-%d %H:%M:%S UTC")*
+          *Plan generated at: $(TZ="Europe/Oslo" date "+%Y-%m-%d %H:%M:%S %Z")*
 
           EOF
 

--- a/.github/workflows/helpers.terraform-plan.yml
+++ b/.github/workflows/helpers.terraform-plan.yml
@@ -117,7 +117,7 @@ jobs:
             fi
 
             cat << EOF > "plans/${ENVIRONMENT}.md"
-          ### Terraform Plan for ${ENVIRONMENT}${WORKING_DIRECTORY_SUFFIX} 🔍
+          ### Terraform Plan for ${ENVIRONMENT}${WORKING_DIRECTORY_SUFFIX}
 
           <details>
           <summary>Show Plan</summary>
@@ -130,7 +130,7 @@ jobs:
           EOF
           else
             cat << EOF > "plans/${ENVIRONMENT}.md"
-          ### Terraform Plan for ${ENVIRONMENT}${WORKING_DIRECTORY_SUFFIX} 🔍
+          ### Terraform Plan for ${ENVIRONMENT}${WORKING_DIRECTORY_SUFFIX}
 
           _No changes detected._
           EOF
@@ -170,6 +170,13 @@ jobs:
         run: |
           COMMENT_FILE=$(mktemp)
 
+          cat << EOF > "$COMMENT_FILE"
+          ## Terraform Plan 🔍
+          *For commit ${{ inputs.git-sha }}*
+          *Plan generated at: $(date -u "+%Y-%m-%d %H:%M:%S UTC")*
+
+          EOF
+
           for plan_file in plans/*.md; do
             [ -f "$plan_file" ] || continue
             cat "$plan_file" >> "$COMMENT_FILE"
@@ -181,11 +188,5 @@ jobs:
             exit 0
           fi
 
-          cat << EOF >> "$COMMENT_FILE"
-          *For commit ${{ inputs.git-sha }}*
-          *Plan generated at: $(date -u "+%Y-%m-%d %H:%M:%S UTC")*
-          EOF
-
           gh pr comment $PR_NUMBER --body-file "$COMMENT_FILE"
-
           rm "$COMMENT_FILE"

--- a/.github/workflows/helpers.terraform-plan.yml
+++ b/.github/workflows/helpers.terraform-plan.yml
@@ -103,7 +103,7 @@ jobs:
             WORKING_DIRECTORY_SUFFIX=""
           fi
 
-          mkdir -p plans
+          mkdir -p temp-plans
 
           if [ "$ANY_CHANGED" == "true" ]; then
             PLAN_OUTPUT=$(cat << 'PLANEOF'
@@ -116,9 +116,9 @@ jobs:
               PLAN_CONTENT="$PLAN_OUTPUT"
             fi
 
-            cat << EOF > "plans/${ENVIRONMENT}.md"
+            cat << EOF > "temp-plans/${ENVIRONMENT}.md"
           <details>
-          <summary>Show Plan for ${ENVIRONMENT}${WORKING_DIRECTORY_SUFFIX}</summary>
+          <summary>Show Plan for <b>${ENVIRONMENT}${WORKING_DIRECTORY_SUFFIX}</b></summary>
 
           \`\`\`terraform
           $PLAN_CONTENT
@@ -127,9 +127,9 @@ jobs:
           </details>
           EOF
           else
-            cat << EOF > "plans/${ENVIRONMENT}.md"
+            cat << EOF > "temp-plans/${ENVIRONMENT}.md"
           <details>
-          <summary>Show Plan for ${ENVIRONMENT}${WORKING_DIRECTORY_SUFFIX}</summary>
+          <summary>Show Plan for <b>${ENVIRONMENT}${WORKING_DIRECTORY_SUFFIX}</b></summary>
 
           _No changes detected._
 
@@ -142,7 +142,7 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: terraform-plan-${{ matrix.environment }}
-          path: plans/${{ matrix.environment }}.md
+          path: temp-plans/${{ matrix.environment }}.md
 
   publish-plan:
     name: Publish Terraform Plan
@@ -160,7 +160,7 @@ jobs:
         uses: actions/download-artifact@v6
         with:
           pattern: terraform-plan-*
-          path: plans
+          path: temp-plans
           merge-multiple: true
 
       - name: Post combined PR comment
@@ -178,7 +178,7 @@ jobs:
 
           EOF
 
-          for plan_file in plans/*.md; do
+          for plan_file in temp-plans/*.md; do
             [ -f "$plan_file" ] || continue
             cat "$plan_file" >> "$COMMENT_FILE"
             echo "" >> "$COMMENT_FILE"


### PR DESCRIPTION
Fikk innspill fra teamet mitt at tre kommentarer for terraform plan kan bli støyete. Endrer slik at vi heller poster en kommentar for terraform plan.

Copilot sammendrag:

This pull request refactors the Terraform plan workflow to improve how Terraform plan outputs are handled and published as part of the CI process. The main changes include saving plan outputs as artifacts, handling cases with no changes, and consolidating plan comments into a single PR comment.

**Terraform Plan Output Handling:**

* The workflow now saves the Terraform plan output for each environment as a markdown file in the `plans` directory, regardless of whether there are changes or not. If there are no changes, a message stating "_No changes detected._" is written instead. [[1]](diffhunk://#diff-944a675be0e1cb0e1611f3035e8ee502a7fcd7d77de4dc4cf0b7cc87d35b039bL92-R119) [[2]](diffhunk://#diff-944a675be0e1cb0e1611f3035e8ee502a7fcd7d77de4dc4cf0b7cc87d35b039bR130-R184)
* The plan output files are uploaded as artifacts using the `actions/upload-artifact` action, making them available for later steps or debugging.

**Publishing and Commenting Enhancements:**

* A new `publish-plan` job is introduced, which downloads all plan artifacts, combines them, and posts a single, consolidated PR comment with the plan results for all environments. This ensures that the PR discussion remains clean and organized, with one comment per plan run.
* The comment posted to the PR now includes metadata such as the commit SHA and the timestamp when the plan was generated, improving traceability.