### PR TITLE
Fix bug for when tf plan exceeds 65k characters

### DIFF
--- a/.github/workflows/helpers.terraform-plan.yml
+++ b/.github/workflows/helpers.terraform-plan.yml
@@ -209,5 +209,14 @@ jobs:
             exit 0
           fi
 
+          # Truncate if too large for GitHub's 65536 char limit
+          if [ $(wc -c < "$COMMENT_FILE") -gt 65000 ]; then
+            head -c 64500 "$COMMENT_FILE" > "${COMMENT_FILE}.tmp"
+            printf '\n%s\n</details>\n\n---\n' '```' >> "${COMMENT_FILE}.tmp"
+            echo "⚠️ **Output truncated.** View full plan in the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})." >> "${COMMENT_FILE}.tmp"
+            mv "${COMMENT_FILE}.tmp" "$COMMENT_FILE"
+          fi
+
           gh pr comment $PR_NUMBER --body-file "$COMMENT_FILE"
           rm "$COMMENT_FILE"
+


### PR DESCRIPTION
Når en terraform plan er for stor (over 65k characters) vil man bli henvist til workflowen.

<img width="930" height="348" alt="image" src="https://github.com/user-attachments/assets/01e45c87-c040-40ad-94c0-c2a1f9890931" />
