### PR TITLE
Add support for overriding pnpm version in workflows

### DIFF
--- a/.github/workflows/build.node.yml
+++ b/.github/workflows/build.node.yml
@@ -37,6 +37,11 @@ on:
         required: false
         type: string
         default: "" # What to upload as artifact
+      pnpm-version:
+        required: false
+        type: string
+        description: "Which version of PNPM to use."
+        default: "10"
       git-sha:
         required: false
         type: string
@@ -90,6 +95,7 @@ jobs:
           NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
           NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
           git-sha: ${{ inputs.git-sha }}
+          pnpm-version: ${{ inputs.pnpm-version }}
 
       - name: Store build as Artifact
         uses: actions/upload-artifact@v6

--- a/.github/workflows/test.node.yml
+++ b/.github/workflows/test.node.yml
@@ -38,6 +38,11 @@ on:
         type: string
         description: "Git SHA to use for versioning"
         default: ${{ github.event.pull_request.head.sha || github.sha }}
+      pnpm-version:
+        required: false
+        type: string
+        description: "Which version of PNPM to use."
+        default: "10"
 
 jobs:
   test:
@@ -82,3 +87,4 @@ jobs:
           NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
           NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
           git-sha: ${{ inputs.git-sha }}
+          pnpm-version: ${{ inputs.pnpm-version }}


### PR DESCRIPTION
Som alle andre dependencies så kjem det nye versjonar. Legger til støtte for å overstyre pnpm versjon i github workflows, fordi PNPM versjon 10 -> 11 har breaking changes