### PR TITLE
Change default Gradle operation from 'test' to 'check'

### DIFF
--- a/.github/workflows/test.gradle.yml
+++ b/.github/workflows/test.gradle.yml
@@ -23,7 +23,7 @@ on:
       gradle-operations:
         required: false
         type: string
-        default: "test -Dorg.gradle.caching=true --no-daemon"
+        default: "check -Dorg.gradle.caching=true --no-daemon"
         description: "Gradle operations to run."
       working-directory:
         required: false


### PR DESCRIPTION
To enable Linting task running automatically, we are changing 'test' to 'check'. Most of the services would run fine without any changes. Some services would need small code changes (ref. https://trello.com/c/S1pkooUg/1878-linting-bør-kjøre-som-default-i-alle-servicer)